### PR TITLE
add stderr redirect to stdout on adduser

### DIFF
--- a/usr/sbin/nsm_sensor_ps-restart
+++ b/usr/sbin/nsm_sensor_ps-restart
@@ -347,7 +347,7 @@ if [ "$OSSEC_AGENT_ENABLED" == "yes" ] && [ -z "$SKIP_OSSEC_AGENT" ]; then
 	fi
 
         # Add OSSEC_AGENT_USER to ossec group
-        adduser $OSSEC_AGENT_USER ossec >/dev/null
+        adduser $OSSEC_AGENT_USER ossec 2>&1 >/dev/null
 
         $ACTION "/usr/bin/ossec_agent.tcl" "-o -f /var/ossec/logs/alerts/alerts.log -i 127.0.0.1 -p $OSSEC_AGENT_LEVEL -c $OSSEC_AGENT_CONF" "$PROCESS_PID_DIR/ossec_agent.pid" "$PROCESS_LOG_DIR/ossec_agent.log" "ossec_agent (sguil)" "$OSSEC_AGENT_USER"
 


### PR DESCRIPTION
When SecurityOnion is installed, but not yet configured, on a base Ubuntu 12.04.5 server install, it creates the watchdog cron.d entry which is called every five minutes.  However, the sguil user has not yet been created, so nsm_sensor_ps-restart calls adduser with an invalid username, and the error is sent to stderr, which generates an email to the default user every five minutes.
By redirecting stderr to stdout (before redirecting stdout to /dev/null), when adduser is called before sosetup is run (sguil user does not yet exist), the adduser error shows up in /var/log/nsm/watchdog.log rather than being mailed to root.
