### PR TITLE
add log directory creation to postinst

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -19,6 +19,10 @@ case "$1" in
 	
 	# Make scripts executable
 	chmod +x /usr/sbin/so-snorby-wipe /usr/sbin/so-bro-cron
+	
+	# create log directory so cron scripts don't complain
+	DIR="/var/log/nsm"
+	[ -d $DIR ] || mkdir -p $DIR
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
This package drops several files into /etc/cron.d that output logs to /var/log/nsm.  If that directory has not yet been created, all of those cron entries generate errors which are sent via email to root.

This change creates the log directory upon package installation rather than relying on a subsequent call to sosetup to create it.  This avoids a deluge of system emails from cron if there's a delay between package installation and system configuration.

An alternative would be to drop all the cron scripts somewhere other than /etc/cron.d, and copy them over during setup (or out if they're for something that's not configured during sosetup).

Also, if the log directory is created during installation, the explicit mkdir(s) in sosetup can eventually be removed, although they don't necessarily cause harm.
