### PR TITLE
Changed behaviour when running script with --force-yes option to allo…

### DIFF
--- a/usr/sbin/nsm_sensor_backup-config
+++ b/usr/sbin/nsm_sensor_backup-config
@@ -165,9 +165,12 @@ then
 	BACKUP_FILE=$PROMPT_RET
 fi
 
-# prompt to backup the configuration
+# prompt to backup the configuration, ignore if --force-yes is used
 prompt_user_yesno "Backup Sensor Configuration" "All configurations for sensor \"$SENSOR_NAME\" will be backed up to:\n$BACKUP_FILE\n\nDo you want to continue?" "N"
-[ "$?" -ne 0 ] && exit 1
+if [ $FORCE_YES == "yes" ]
+then
+        PROMPT_RET=Y
+fi
 if [ "$PROMPT_RET" != "Y" -a "$PROMPT_RET" != "y" ]
 then
 	exit 1

--- a/usr/sbin/nsm_server_backup-config
+++ b/usr/sbin/nsm_server_backup-config
@@ -162,8 +162,13 @@ then
 	BACKUP_FILE=$PROMPT_RET
 fi
 
-# prompt to backup the configuration
+# prompt to backup the configuration, ignore if --force-yes is used
 prompt_user_yesno "Backup Server Configuration" "All configurations for server \"$SERVER_NAME\" will be backed up to:\n$BACKUP_FILE\n\nDo you want to continue?" "N"
+Do you want to continue?" "N"
+if [ $FORCE_YES == "yes" ]
+then
+	PROMPT_RET=Y
+fi
 [ "$?" -ne 0 ] && exit 1
 if [ "$PROMPT_RET" != "Y" -a "$PROMPT_RET" != "y" ]
 then


### PR DESCRIPTION
Changed behaviour when running script with --force-yes option to allow it to be used from within an automated backup task, it would fail otherwise as the original expects the user to enter a choice to continue.
