### PR TITLE
nsm_server/sensor_backup_config: add quotes to FORCE_YES #944

### DIFF
--- a/usr/sbin/nsm_sensor_backup-config
+++ b/usr/sbin/nsm_sensor_backup-config
@@ -167,7 +167,7 @@ fi
 
 # prompt to backup the configuration, ignore if --force-yes is used
 prompt_user_yesno "Backup Sensor Configuration" "All configurations for sensor \"$SENSOR_NAME\" will be backed up to:\n$BACKUP_FILE\n\nDo you want to continue?" "N"
-if [ $FORCE_YES == "yes" ]
+if [ "$FORCE_YES" == "yes" ]
 then
         PROMPT_RET=Y
 fi

--- a/usr/sbin/nsm_server_backup-config
+++ b/usr/sbin/nsm_server_backup-config
@@ -164,7 +164,7 @@ fi
 
 # prompt to backup the configuration, ignore if --force-yes is used
 prompt_user_yesno "Backup Server Configuration" "All configurations for server \"$SERVER_NAME\" will be backed up to:\n$BACKUP_FILE\n\nDo you want to continue?" "N"
-if [ $FORCE_YES == "yes" ]
+if [ "$FORCE_YES" == "yes" ]
 then
 	PROMPT_RET=Y
 fi


### PR DESCRIPTION
Issue #944

Fixes:

"/usr/sbin/nsm_sensor_backup-config: line 170: [: ==: unary operator expected"

noted here:

https://groups.google.com/d/msg/security-onion-testing/tGXKlYusqLg/7_lX42u3AwAJ

Thanks,
Wes
