### PR TITLE
redirect iostreams to logfile during ossec-agent restart

### DIFF
--- a/usr/lib/nsmnow/lib-nsm-common-utils
+++ b/usr/lib/nsmnow/lib-nsm-common-utils
@@ -955,10 +955,10 @@ process_start()
 	if [ "$#" -eq "6" ]; then
 
 	        # Create home dir if it doesn't already exist
-	        mkdir -p /home/$USER
+	        mkdir -p /home/$USER >>$LOG_FILE 2>&1
 
         	# Set permissions
-       		chown -R $USER /home/$USER
+       		chown -R $USER /home/$USER >>$LOG_FILE 2>&1
 
 		# Exec as user in user's home directory
 		eval exec su - $USER -- "$APP $APP_OPTIONS" >>$LOG_FILE 2>&1 &


### PR DESCRIPTION
Redirect output of mkdir and chown lines to logfile.

Without this, if SecurityOnion is installed on Ubuntu Server but not yet configured, the user sguil does not exist yet, and cron generates a daily email with "chown: invalid user: ???sguil???" when running nsm_sensor_ps-restart --only-ossec-agent from /etc/cron.d/sensor-newday file.
