### PR TITLE
stderr redirects when listing logfiles

### DIFF
--- a/usr/lib/nsmnow/lib-nsm-common-utils
+++ b/usr/lib/nsmnow/lib-nsm-common-utils
@@ -1097,7 +1097,7 @@ process_restart()
 
 	# Rotate the log file and keep a maximum of 10	
 	[ -f "$LOG_FILE" ] && mv "$LOG_FILE" "$LOG_FILE".`date +%Y%m%d%H%M%S`
-	[ `ls "$LOG_FILE".* |wc -l` -gt 10 ] && ls "$LOG_FILE".* |head -1 |xargs rm -f
+	[ `ls "$LOG_FILE".* 2>/dev/null|wc -l` -gt 10 ] && ls "$LOG_FILE".* |head -1 |xargs rm -f
 
 	# Start the process
 	if [ "$#" -eq "6" ]; then
@@ -1154,7 +1154,7 @@ process_restart_if_stale()
         		process_stop "$APP" "$PID_FILE" "$APP_DESC"
 			# Rotate the log file and keep a maximum of 10	
 			[ -f "$LOG_FILE" ] && mv "$LOG_FILE" "$LOG_FILE".`date +%Y%m%d%H%M%S`
-			[ `ls "$LOG_FILE".* |wc -l` -gt 10 ] && ls "$LOG_FILE".* |head -1 |xargs rm -f
+			[ `ls "$LOG_FILE".* 2>/dev/null|wc -l` -gt 10 ] && ls "$LOG_FILE".* |head -1 |xargs rm -f
 			if [ "$#" -eq "6" ]; then
 				process_start "$APP" "$APP_OPTIONS" "$PID_FILE" "$LOG_FILE" "$APP_DESC" "$USER"
 			else
@@ -1213,7 +1213,7 @@ process_restart_with_overlap()
 		else
 			# Rotate the log file and keep a maximum of 10	
 			[ -f "$LOG_FILE" ] && mv "$LOG_FILE" "$LOG_FILE".`date +%Y%m%d%H%M%S`
-			[ `ls "$LOG_FILE".* |wc -l` -gt 10 ] && ls "$LOG_FILE".* |head -1 |xargs rm -f
+			[ `ls "$LOG_FILE".* 2>/dev/null|wc -l` -gt 10 ] && ls "$LOG_FILE".* |head -1 |xargs rm -f
 
 			rm -f $PID_FILE
 			process_start "$APP" "$APP_OPTIONS" "$PID_FILE" "$LOG_FILE" "$APP_DESC"


### PR DESCRIPTION
If a logfile does not exist, certain ls commands generate stderr output.  When run from cron, if a mailer is installed, a mail is generated with output such as:
  ls: cannot access /var/log/nsm/host-p2p1/snort_agent-10.log.*: No such file or directory

To duplicate, install SecurityOnion in production mode, install a mailer, such as exim4-daemon-light, then without stopping sensor processes first, manually increase the IDS_LB_PROCS variable in /etc/nsm/<sensor-name>/sensor.conf, and wait for the watchdog cronjob to fire.