### PR TITLE
NSM: cron job to check if netsniff-ng is recording with a date other than today

### DIFF
--- a/etc/cron.d/netsniff-sync
+++ b/etc/cron.d/netsniff-sync
@@ -1,0 +1,8 @@
+# /etc/cron.d/elsa
+#
+# crontab entry for netsniff-ng
+
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+* * * * * root /usr/sbin/so-netsniff-ng-cron > /dev/null 2>&1

--- a/etc/cron.d/netsniff-sync
+++ b/etc/cron.d/netsniff-sync
@@ -1,4 +1,4 @@
-# /etc/cron.d/elsa
+# /etc/cron.d/netsniff
 #
 # crontab entry for netsniff-ng
 

--- a/usr/sbin/so-netsniff-ng-cron
+++ b/usr/sbin/so-netsniff-ng-cron
@@ -3,32 +3,23 @@
 # Define initial variables
 SENSORTAB="/etc/nsm/sensortab"
 INTERFACES=$(grep -v '#' $SENSORTAB | awk '{print $1}')
-NETSNIFF_ENABLED="no"
-NETSNIFF_RUNNING="no"
 OS_DATE=$(date +"%Y-%m-%d")
 
 # Check to see if netsniff-ng is enabled.
 for i in $INTERFACES; do
 	if grep -q 'PCAP_ENABLED="yes"' /etc/nsm/$i/sensor.conf; then
-		NETSNIFF_ENABLED="yes"
+		# Check to see if netsniff-ng is running.
+        	if pgrep -af netsniff-ng > /dev/null 2>&1; then
+        		NETSNIFF_DATE=$(pgrep -af -oldest netsniff-ng | cut -d'/' -f6)
+        		if [ "$NETSNIFF_DATE" == $OS_DATE ]; then
+        			exit
+			else
+        			nsm_sensor_ps-restart --sensor-name=$i --only-pcap > /dev/null 2>&1 && echo "$(date) -  netsniff-ng for $i was restarted due to a date mismatch (Current date is: $OS_DATE.  Previously writing to /nsm/sensor_data/$i/dailylogs/$NETSNIFF_DATE)." >> /var/log/nsm/netsniff-sync.log
+			fi
+		else
+			exit
+		fi
+	else
+		exit
 	fi
 done
-
-# Check to see if netsniff-ng is running.
-if NETSNIFF_ENABLED="yes"; then
-	if pgrep -af netsniff-ng > /dev/null 2>&1; then
-		NETSNIFF_RUNNING="yes"
-	fi 
-fi
-
-# Check if netsniff-ng is 
-if NETSNIFF_RUNNING="yes"; then
-	NETSNIFF_DATE=$(pgrep -af -oldest netsniff-ng | cut -d'/' -f6)	
-fi
-
-# If netsniff-ng date and OS date are not equal, restart netsniff-ng
-if [ "$NETSNIFF_DATE" == $OS_DATE ]; then
-	exit
-else
-	nsm_sensor_ps-restart --only-pcap > /dev/null 2>&1 && echo "$(date) -  netsniff-ng was restarted due to a date mismatch (Current date is: $OS_DATE.  Previously writing to $NETSNIFF_DATE)." > /var/log/nsm/netsniff-sync.log
-fi

--- a/usr/sbin/so-netsniff-ng-cron
+++ b/usr/sbin/so-netsniff-ng-cron
@@ -11,7 +11,7 @@ for i in $INTERFACES; do
 		# Check to see if netsniff-ng is running.
         	if pgrep -af netsniff-ng > /dev/null 2>&1; then
         		NETSNIFF_DATE=$(pgrep -af -oldest netsniff-ng | cut -d'/' -f6)
-        		if [ "$NETSNIFF_DATE" == $OS_DATE ]; then
+        		if [ "$NETSNIFF_DATE" != $OS_DATE ]; then
         			nsm_sensor_ps-restart --sensor-name=$i --only-pcap > /dev/null 2>&1 && echo "$(date) -  netsniff-ng for $i was restarted due to a date mismatch (Current date is: $OS_DATE.  Previously writing to /nsm/sensor_data/$i/dailylogs/$NETSNIFF_DATE)." >> /var/log/nsm/netsniff-sync.log
 			fi
 		fi

--- a/usr/sbin/so-netsniff-ng-cron
+++ b/usr/sbin/so-netsniff-ng-cron
@@ -11,7 +11,7 @@ for i in $INTERFACES; do
 		# Check to see if netsniff-ng is running.
         	if pgrep -af netsniff-ng.*/nsm/sensor_data/$i > /dev/null 2>&1; then
         		NETSNIFF_DATE=$(pgrep -af -oldest netsniff-ng | cut -d'/' -f6)
-        		if [ "$NETSNIFF_DATE" == $OS_DATE ]; then
+        		if [ "$NETSNIFF_DATE" != $OS_DATE ]; then
         			nsm_sensor_ps-restart --sensor-name=$i --only-pcap > /dev/null 2>&1 && echo "$(date) -  netsniff-ng for $i was restarted due to a date mismatch (Current date is: $OS_DATE.  Previously writing to /nsm/sensor_data/$i/dailylogs/$NETSNIFF_DATE)." >> /var/log/nsm/netsniff-sync.log
 			fi
 		fi

--- a/usr/sbin/so-netsniff-ng-cron
+++ b/usr/sbin/so-netsniff-ng-cron
@@ -3,6 +3,7 @@
 # Define initial variables
 SENSORTAB="/etc/nsm/sensortab"
 INTERFACES=$(grep -v '#' $SENSORTAB | awk '{print $1}')
+NETSNIFF_ENABLED="no"
 OS_DATE=$(date +"%Y-%m-%d")
 
 # Check to see if netsniff-ng is enabled.
@@ -12,14 +13,8 @@ for i in $INTERFACES; do
         	if pgrep -af netsniff-ng > /dev/null 2>&1; then
         		NETSNIFF_DATE=$(pgrep -af -oldest netsniff-ng | cut -d'/' -f6)
         		if [ "$NETSNIFF_DATE" == $OS_DATE ]; then
-        			exit
-			else
         			nsm_sensor_ps-restart --sensor-name=$i --only-pcap > /dev/null 2>&1 && echo "$(date) -  netsniff-ng for $i was restarted due to a date mismatch (Current date is: $OS_DATE.  Previously writing to /nsm/sensor_data/$i/dailylogs/$NETSNIFF_DATE)." >> /var/log/nsm/netsniff-sync.log
 			fi
-		else
-			exit
 		fi
-	else
-		exit
 	fi
 done

--- a/usr/sbin/so-netsniff-ng-cron
+++ b/usr/sbin/so-netsniff-ng-cron
@@ -10,7 +10,7 @@ for i in $INTERFACES; do
 	if grep -q 'PCAP_ENABLED="yes"' /etc/nsm/$i/sensor.conf; then
 		# Check to see if netsniff-ng is running.
         	if pgrep -af netsniff-ng.*/nsm/sensor_data/$i > /dev/null 2>&1; then
-        		NETSNIFF_DATE=$(pgrep -af -oldest netsniff-ng | cut -d'/' -f6)
+        		NETSNIFF_DATE=$(pgrep -af netsniff-ng.*/nsm/sensor_data/$i | cut -d'/' -f6)
         		if [ "$NETSNIFF_DATE" != $OS_DATE ]; then
         			nsm_sensor_ps-restart --sensor-name=$i --only-pcap > /dev/null 2>&1 && echo "$(date) -  netsniff-ng for $i was restarted due to a date mismatch (Current date is: $OS_DATE.  Previously writing to /nsm/sensor_data/$i/dailylogs/$NETSNIFF_DATE)." >> /var/log/nsm/netsniff-sync.log
 			fi

--- a/usr/sbin/so-netsniff-ng-cron
+++ b/usr/sbin/so-netsniff-ng-cron
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Define initial variables
+SENSORTAB="/etc/nsm/sensortab"
+INTERFACES=$(grep -v '#' $SENSORTAB | awk '{print $1}')
+NETSNIFF_ENABLED="no"
+NETSNIF_RUNNING="no"
+OS_DATE=$(date +"%Y-%m-%d")
+
+# Check to see if netsniff-ng is enabled.
+for i in $INTERFACES; do
+	if grep -q 'PCAP_ENABLED="yes"' /etc/nsm/$i/sensor.conf; then
+		NETSNIFF_ENABLED="yes"
+	fi
+done
+
+# Check to see if netsniff-ng is running.
+if NETSNIFF_ENABLED="yes"; then
+	if pgrep -af netsniff-ng > /dev/null 2>&1; then
+		NETSNIFF_RUNNING="yes"
+	fi 
+fi
+
+# Check if netsniff-ng is 
+if NETSNIFF_RUNNING="yes"; then
+	NETSNIFF_DATE=$(pgrep -af -oldest netsniff-ng | cut -d'/' -f6)	
+fi
+
+# If netsniff-ng date and OS date are not equal, restart netsniff-ng
+if [ "$NETSNIFF_DATE" == $OS_DATE ]; then
+	exit
+else
+	nsm_sensor_ps-restart --only-pcap > /dev/null 2>&1 && echo "$(date) -  netsniff-ng was restarted due to a date mismatch (Current date is: $OS_DATE.  Previously writing to $NETSNIFF_DATE)." > /var/log/nsm/netsniff-sync.log
+fi

--- a/usr/sbin/so-netsniff-ng-cron
+++ b/usr/sbin/so-netsniff-ng-cron
@@ -4,7 +4,7 @@
 SENSORTAB="/etc/nsm/sensortab"
 INTERFACES=$(grep -v '#' $SENSORTAB | awk '{print $1}')
 NETSNIFF_ENABLED="no"
-NETSNIF_RUNNING="no"
+NETSNIFF_RUNNING="no"
 OS_DATE=$(date +"%Y-%m-%d")
 
 # Check to see if netsniff-ng is enabled.

--- a/usr/sbin/so-netsniff-ng-cron
+++ b/usr/sbin/so-netsniff-ng-cron
@@ -9,9 +9,9 @@ OS_DATE=$(date +"%Y-%m-%d")
 for i in $INTERFACES; do
 	if grep -q 'PCAP_ENABLED="yes"' /etc/nsm/$i/sensor.conf; then
 		# Check to see if netsniff-ng is running.
-        	if pgrep -af netsniff-ng > /dev/null 2>&1; then
+        	if pgrep -af netsniff-ng.*/nsm/sensor_data/$i > /dev/null 2>&1; then
         		NETSNIFF_DATE=$(pgrep -af -oldest netsniff-ng | cut -d'/' -f6)
-        		if [ "$NETSNIFF_DATE" != $OS_DATE ]; then
+        		if [ "$NETSNIFF_DATE" == $OS_DATE ]; then
         			nsm_sensor_ps-restart --sensor-name=$i --only-pcap > /dev/null 2>&1 && echo "$(date) -  netsniff-ng for $i was restarted due to a date mismatch (Current date is: $OS_DATE.  Previously writing to /nsm/sensor_data/$i/dailylogs/$NETSNIFF_DATE)." >> /var/log/nsm/netsniff-sync.log
 			fi
 		fi

--- a/usr/sbin/so-netsniff-ng-cron
+++ b/usr/sbin/so-netsniff-ng-cron
@@ -3,7 +3,6 @@
 # Define initial variables
 SENSORTAB="/etc/nsm/sensortab"
 INTERFACES=$(grep -v '#' $SENSORTAB | awk '{print $1}')
-NETSNIFF_ENABLED="no"
 OS_DATE=$(date +"%Y-%m-%d")
 
 # Check to see if netsniff-ng is enabled.


### PR DESCRIPTION
In reference to:
https://github.com/Security-Onion-Solutions/security-onion/issues/1117

**cron job**: `/etc/cron.d/netsniff-sync`
**script**: `/usr/sbin/so-netsniff-ng-cron`
**log**: `/var/log/nsm/netsniff-sync.log`