### PR TITLE
Delay watchdog checks while any other nsm_sensor_ps script runs

### DIFF
--- a/usr/lib/nsmnow/lib-nsm-common-utils
+++ b/usr/lib/nsmnow/lib-nsm-common-utils
@@ -1139,6 +1139,26 @@ process_restart_if_stale()
         APP_DESC=${5:-}
 	USER=${6:-}
 
+	# don't run while any other nsm_sensor_ps script is running
+        if [ $(pgrep -c nsm_sensor_ps) -gt 1 ]
+        then
+                echo_msg_begin 1 "waiting for other nsmnow process control script to stop"
+                sleep 1
+                loop=2
+                while [ $(pgrep -c nsm_sensor_ps) -gt 1 ]
+                do
+                        if [ $loop -ge 30 ]
+                        then
+                                echo_msg_end 1 "aborting after $loop checks"
+                                echo "nsm_sensor_ps process_restart_if_stale function call exited with error" 1>&2
+                                exit 1
+                        fi
+                        sleep 1
+                        loop=$((loop + 1))
+                done
+                echo_msg_end 2 "continuing after $loop checks"
+        fi
+
 	# check for PID file
         if [ -f $PID_FILE ]
         then


### PR DESCRIPTION
This check pauses the --if-stale checks run by the watchdog cron job if it
detects any other nsm_sensor_ps script running.  This prevents race conditions
such as when rule_update or daily_restart is starting/stopping processes, and
watchdog interferes, leaving an extra process running.

History:
----------
I would often find an extra pcap_agent (and occasionally a snort alert process) running after the automated daily restarts and/or rule-update processes run.  The most recent showed these symptoms:


> $ ps -ef|grep [p]cap_agent
> root      18533      1  0 12:04 ?        00:00:00 su - sguil -- /usr/bin/pcap_agent.tcl -c /etc/nsm/mysensor-em2/pcap_agent.conf
> sguil     18535  18533  0 12:04 ?        00:00:00 tclsh /usr/bin/pcap_agent.tcl -c /etc/nsm/mysensor-em2/pcap_agent.conf
> root      18567      1  0 12:04 ?        00:00:00 su - sguil -- /usr/bin/pcap_agent.tcl -c /etc/nsm/mysensor-em2/pcap_agent.conf
> sguil     18569  18567  0 12:04 ?        00:00:00 tclsh /usr/bin/pcap_agent.tcl -c /etc/nsm/mysensor-em2/pcap_agent.conf

(relevant portion of watchdog.log)
> Tue May  8 12:04:01 UTC 2018
>   * stale PID file found, deleting!
>   * stopping: pcap_agent (sguil) (not running)[ WARN ]
>   * starting: pcap_agent (sguil)[  OK  ]

Note that the timestamp in the logfile matches the time that the duplicate processes were created.  This is also four minutes after the sensor-newday cron job runs, but also right when the nsm-watchdog cron job runs.

Solution:
---------
In the lib-nsm-common-utils library in the function that handles restarts of stale processes (when run with the --if-stale flag by the watchdog cron job), check to see if any other of the nsm_sensor_ps-* scripts are running, and if so, pause, checking every second up to 30 times.  If other scripts end, continue with the --if-stale checks.  If they're still running after 30 checks, abort.

Note that it reports the error using echo_msg_end, but it also echos to stderr, which generates an email from cron to root if you have a mailer configured on the system.  This is to alert on timeouts rather than just hide in the watchdog.log file.  At most, it will generate an email every 5 minutes, so there should not be an uncontrollable flood, and emails only ever go out if a mailer such as exim4 is installed and configured on the sensor.

Testing:
--------
The patch author's recommended testing method:
* Install SecurityOnion in advanced mode, with multiple snort IDS processes and multiple monitored interfaces if possible (as many as your memory/resources allow).
* (optional) Increase the frequency of watchdog checks from every 5 minutes to every 1 minute by replacing '4,9,14,19,24,29,34,39,44,49,54,59' with '*' in /etc/cron.d/nsm-watchdog.
* Follow the end of the watchdog.log file using 'tail -f /var/log/nsm/watchdog.log'
* In another window, continuously restart the sensor processes by running 'nsm_sensor_ps-restart' until a log entry shows that watchdog restarted a stale process.
* Verify that there is an additional process as identified in the logfile started by the watchdog script (failure condition).
* Install this patch
* Follow the end of the watchdog.log file using 'tail -f /var/log/nsm/watchdog.log'
* Restart the sensor processes until you see a watchdog.log entry warning on the order of "waiting for other nsmnow process control script to stop (continuing after 2 checks)" (new feature: watchdog action delayed)
* Pause a status check (nsm --sensor --status) by quickly pressing Ctrl-S (aka XOFF) while running, and wait for a log entry failure on the order of "waiting for other nsmnow process control script to stop (aborting after 30 checks)" then resume by pressing Ctrl-Q (aka XON). (feature failsafe: watchdog action aborted)
* (optional) If a mailer is installed, check for an email containing the message body of "nsm_sensor_ps process_restart_if_stale function call exited with error" (failsafe feature: stdout alert on fail)
* Kill one or more sensor processes using the "kill" or "pkill" command (eg. 'sudo pkill snort' and/or 'sudo pkill -f "tclsh /usr/bin/.*agent.tcl" ') and wait for a watchdog log entry showing all those processes have been restarted (routine action still works)
* Check that all processes show OK after watchdog restart by running 'nsm --all --status'