### PR TITLE
add cron jobs for backing up server/sensor config daily

### DIFF
--- a/etc/cron.d/sensor-backup-config
+++ b/etc/cron.d/sensor-backup-config
@@ -1,0 +1,7 @@
+# /etc/cron.d/sensor-backup-config
+#
+# crontab entry to backup server config; purge backups older than 10 days
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+* * * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; for i in $(cat /etc/nsm/sensortab | grep -v '#' | awk '{print $1}'); do /usr/sbin/nsm_sensor_backup-config --force-yes --sensor-name=$i --backup-file=/etc/nsm/backup/$i-sensor-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/$i-backup-config.log 2>&1; done; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +10 -exec rm -f {} \;
+

--- a/etc/cron.d/sensor-backup-config
+++ b/etc/cron.d/sensor-backup-config
@@ -1,7 +1,7 @@
 # /etc/cron.d/sensor-backup-config
 #
-# crontab entry to backup server config; purge backups older than 10 days
+# crontab entry to backup sensor config; purge backups older than 10 days
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-0 1 * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; for i in $(cat /etc/nsm/sensortab | grep -v '#' | awk '{print $1}'); do /usr/sbin/nsm_sensor_backup-config --force-yes --sensor-name=$i --backup-file=/etc/nsm/backup/$i-sensor-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/$i-backup-config.log 2>&1; done; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +10 -exec rm -f {} \;
+0 1 * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; for i in $(cat /etc/nsm/sensortab | grep -v '#' | awk '{print $1}'); do /usr/sbin/nsm_sensor_backup-config --force-yes --sensor-name=$i --backup-file=/etc/nsm/backup/$i-sensor-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/$i-backup-config.log 2>&1; done; /usr/bin/find  /etc/nsm/backup/*sensor-backup*.tar.gz -mtime +10 -exec rm -f {} \;
 

--- a/etc/cron.d/sensor-backup-config
+++ b/etc/cron.d/sensor-backup-config
@@ -1,7 +1,8 @@
 # /etc/cron.d/sensor-backup-config
 #
 # crontab entry to backup sensor config; purge backups older than 10 days
+DAYSTOKEEP=10
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-0 1 * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; for i in $(cat /etc/nsm/sensortab | grep -v '#' | awk '{print $1}'); do /usr/sbin/nsm_sensor_backup-config --force-yes --sensor-name=$i --backup-file=/etc/nsm/backup/$i-sensor-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/$i-backup-config.log 2>&1; done; /usr/bin/find  /etc/nsm/backup/*sensor-backup*.tar.gz -mtime +10 -exec rm -f {} \;
+0 1 * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; for i in $(cat /etc/nsm/sensortab | grep -v '#' | awk '{print $1}'); do /usr/sbin/nsm_sensor_backup-config --force-yes --sensor-name=$i --backup-file=/etc/nsm/backup/$i-sensor-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/$i-backup-config.log 2>&1; done; /usr/bin/find  /etc/nsm/backup/*sensor-backup*.tar.gz -mtime +$DAYSTOKEEP -exec rm -f {} \;
 

--- a/etc/cron.d/sensor-backup-config
+++ b/etc/cron.d/sensor-backup-config
@@ -3,5 +3,5 @@
 # crontab entry to backup server config; purge backups older than 10 days
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-* * * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; for i in $(cat /etc/nsm/sensortab | grep -v '#' | awk '{print $1}'); do /usr/sbin/nsm_sensor_backup-config --force-yes --sensor-name=$i --backup-file=/etc/nsm/backup/$i-sensor-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/$i-backup-config.log 2>&1; done; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +10 -exec rm -f {} \;
+0 1 * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; for i in $(cat /etc/nsm/sensortab | grep -v '#' | awk '{print $1}'); do /usr/sbin/nsm_sensor_backup-config --force-yes --sensor-name=$i --backup-file=/etc/nsm/backup/$i-sensor-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/$i-backup-config.log 2>&1; done; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +10 -exec rm -f {} \;
 

--- a/etc/cron.d/server-backup-config
+++ b/etc/cron.d/server-backup-config
@@ -1,0 +1,8 @@
+# /etc/cron.d/sensor-backup-config
+#
+# crontab entry to backup server config; purge backups older than 10 days
+
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+* * * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; /usr/sbin/nsm_server_backup-config --force-yes --server-name=securityonion --backup-file=/etc/nsm/backup/securityonion-server-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/server-backup-config.log 2>&1; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +10 -exec rm -f {} \;
+

--- a/etc/cron.d/server-backup-config
+++ b/etc/cron.d/server-backup-config
@@ -4,5 +4,5 @@
 
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-* * * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; /usr/sbin/nsm_server_backup-config --force-yes --server-name=securityonion --backup-file=/etc/nsm/backup/securityonion-server-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/server-backup-config.log 2>&1; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +10 -exec rm -f {} \;
+0 1 * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; /usr/sbin/nsm_server_backup-config --force-yes --server-name=securityonion --backup-file=/etc/nsm/backup/securityonion-server-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/server-backup-config.log 2>&1; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +10 -exec rm -f {} \;
 

--- a/etc/cron.d/server-backup-config
+++ b/etc/cron.d/server-backup-config
@@ -1,4 +1,4 @@
-# /etc/cron.d/sensor-backup-config
+# /etc/cron.d/server-backup-config
 #
 # crontab entry to backup server config; purge backups older than 10 days
 

--- a/etc/cron.d/server-backup-config
+++ b/etc/cron.d/server-backup-config
@@ -4,5 +4,5 @@
 DAYSTOKEEP=10
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-0 1 * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; /usr/sbin/nsm_server_backup-config --force-yes --server-name=securityonion --backup-file=/etc/nsm/backup/securityonion-server-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/server-backup-config.log 2>&1; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +1$DAYSTOKEEP -exec rm -f {} \;
+0 1 * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; /usr/sbin/nsm_server_backup-config --force-yes --server-name=securityonion --backup-file=/etc/nsm/backup/securityonion-server-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/server-backup-config.log 2>&1; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +$DAYSTOKEEP -exec rm -f {} \;
 

--- a/etc/cron.d/server-backup-config
+++ b/etc/cron.d/server-backup-config
@@ -1,8 +1,8 @@
 # /etc/cron.d/server-backup-config
 #
 # crontab entry to backup server config; purge backups older than 10 days
-
+DAYSTOKEEP=10
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-0 1 * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; /usr/sbin/nsm_server_backup-config --force-yes --server-name=securityonion --backup-file=/etc/nsm/backup/securityonion-server-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/server-backup-config.log 2>&1; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +10 -exec rm -f {} \;
+0 1 * * * root if [ -d /etc/nsm/backup ]; then :; else mkdir /etc/nsm/backup; fi; /usr/sbin/nsm_server_backup-config --force-yes --server-name=securityonion --backup-file=/etc/nsm/backup/securityonion-server-backup-`date +\%Y-\%m-\%d`.tar.gz >> /var/log/nsm/server-backup-config.log 2>&1; /usr/bin/find  /etc/nsm/backup/*server-backup*.tar.gz -mtime +1$DAYSTOKEEP -exec rm -f {} \;
 


### PR DESCRIPTION
-Add cron jobs for backing up server/sensor configs daily (1AM default)
(using `nsm_server_backup-config` and `nsm_sensor_backup-config`)
-Backs up to:   
 `/etc/nsm/backup/securityonion-server-backup-$DATE.tar.gz`
`/etc/nsm/backup/<sensorname-interface>-sensor-backup-$DATE.tar.gz`

-Logs to:   
`/var/log/nsm/securityonion-server-backup-config.log`
` /var/log/nsm/<sensorname-interface>-backup-config.log` 

Purges config file backups after 10 days (configurable by `DAYSTOKEEP` value in each cron job)