### PR TITLE
replace bash expansion with find

### DIFF
--- a/usr/lib/nsmnow/lib-nsm-sensor-utils
+++ b/usr/lib/nsmnow/lib-nsm-sensor-utils
@@ -375,7 +375,7 @@ sensor_cleandisk()
 				        CUR_USAGE=$(df -P $SENSOR_DIR | tail -1 | awk '{print $5}' | tr -d %)
 				done
 				# if we're out of pcaps to delete, then increment variable
-				if [ `ls $SENSOR/dailylogs/$TODAY/snort.log.* | wc -l` -le 1 ]; then
+				if [ `find $SENSOR/dailylogs/$TODAY/ -iname 'snort.log.*' | wc -l` -le 1 ]; then
 					echo_msg 1 "${RED}no old pcaps available to clean up in $SENSOR/dailylogs/"
 					let SENSORS_WITH_NO_PCAPS_TO_DELETE++
 				fi

--- a/usr/lib/nsmnow/lib-nsm-sensor-utils
+++ b/usr/lib/nsmnow/lib-nsm-sensor-utils
@@ -375,7 +375,7 @@ sensor_cleandisk()
 				        CUR_USAGE=$(df -P $SENSOR_DIR | tail -1 | awk '{print $5}' | tr -d %)
 				done
 				# if we're out of pcaps to delete, then increment variable
-				if [ `find $SENSOR/dailylogs/$TODAY/ -iname 'snort.log.*' | wc -l` -le 1 ]; then
+				if [ `find $SENSOR/dailylogs/$TODAY/ -name 'snort.log.*' | wc -l` -le 1 ]; then
 					echo_msg 1 "${RED}no old pcaps available to clean up in $SENSOR/dailylogs/"
 					let SENSORS_WITH_NO_PCAPS_TO_DELETE++
 				fi


### PR DESCRIPTION
Remove the bash expansion of the check to see if any pcaps are remaining. and replace with find command. 

On sensors with lots of files in a single daily logs directory this causes netsniff-ng to stop as the bash expansion fails. the cleanup script reduces usage down to 90% but by the time it moves onto the next step it's over the threshold again. 

ls: cannot access '/nsm/sensor_data/hostname-eth0/argus': No such file or directory
  * no old argus files available to clean up in /nsm/sensor_data/hostname-eth0/argus/
  * no old unified2 files available to clean up in /nsm/sensor_data/hostname-eth0/
  * no old unified2 files available to clean up in /nsm/sensor_data/hostname-eth0/
  * removing pcap from today's directory: /nsm/sensor_data/hostname-eth1/dailylogs/2019-10-16/snort.log.1571186596
/usr/lib/nsmnow/lib-nsm-sensor-utils: line 378: /bin/ls: Argument list too long
  * no old pcaps available to clean up in /nsm/sensor_data/hostname-eth1/dailylogs/
  * no old argus files available to clean up in /nsm/sensor_data/hostname-eth1/argus/
  * no old unified2 files available to clean up in /nsm/sensor_data/hostname-eth1/
  * no old unified2 files available to clean up in /nsm/sensor_data/hostname-eth1/