### PR TITLE
add ability to pin snort via IDS_LB_CPUS var

### DIFF
--- a/usr/sbin/nsm_sensor_ps-start
+++ b/usr/sbin/nsm_sensor_ps-start
@@ -603,7 +603,14 @@ do
 			UNI_DIR=$SENSOR_LOG_DIR/snort-$i
 			mkdir -p $UNI_DIR
 			chown $SENSOR_USER:$SENSOR_GROUP $UNI_DIR
-   			[ "$IDS_ENGINE_ENABLED" == "yes" ] && [ -z "$SKIP_SNORT_ALERT" ] && process_start "snort" "-c $SNORT_CONFIG -u $SENSOR_USER -g $SENSOR_GROUP -i $SENSOR_INTERFACE_SHORT $BPF_OPTION -l $UNI_DIR --perfmon-file $PERFMON $SNORT_OPTIONS --snaplen $MTU_FIN" "$PID" "$LOG" "snort-$i (alert data)"
+                        TASKSET=""
+                        if [ -n "$IDS_LB_CPUS" ]; then
+                                IDS_CORE=$(echo "$IDS_LB_CPUS" | cut -d, -f$i)
+				if [ "$IDS_CORE" -gt 0 2>/dev/null ]; then
+					TASKSET="taskset -c $IDS_CORE "
+				fi
+                        fi
+                        [ "$IDS_ENGINE_ENABLED" == "yes" ] && [ -z "$SKIP_SNORT_ALERT" ] && process_start "${TASKSET}snort" "-c $SNORT_CONFIG -u $SENSOR_USER -g $SENSOR_GROUP -i $SENSOR_INTERFACE_SHORT $BPF_OPTION -l $UNI_DIR --perfmon-file $PERFMON $SNORT_OPTIONS --snaplen $MTU_FIN" "$PID" "$LOG" "snort-$i (alert data)"
 		done
 	fi
 


### PR DESCRIPTION
This may be a starting point for the ability to pin snort processes to specific CPUs by adding a line to the /etc/nsm/<sensor>/sensor.conf file like:

> IDS_LB_CPUS=1,3,5,7
 
As specified, the first four snort processes would be pinned to the first four odd-numbered CPU cores.  It validates the input as a number before using it, so if there are more than the specified number (eg 5), any processes without a CPU listed would have the default CPU affinity.

This is admittedly a little hackish, as the CPU for taskset should probably be specified as a seventh parameter to process_start() instead of specifying both taskset and the command to run in the first (CMD) parameter.

To test, I recommend first moving all processes to a specific set of CPUs using systemd's CPUAffinity setting in /etc/systemd/system.conf and specifying values for --cpuset-cpus in the docker containers using the *_OPTIONS values in /etc/nsm/securityonion.conf.  The htop utility can be useful for verifying that the CPUs not given there are idle.  Then, you can test this setting and verify that the processes are moved to the CPUs idled earlier.